### PR TITLE
add module declaration file with VueMarkdownIt component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vue3-markdown-it",
       "version": "1.0.9",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,14 @@
     "markdown",
     "markdown-it"
   ],
+  "types": "types/vue3-markdown-it.d.ts",
   "main": "dist/vue3-markdown-it.umd.min.js",
+  "files": [
+    "dist/vue3-markdown-it.umd.min.js",
+    "dist/vue3-markdown-it.umd.min.js.map",
+    "types/vue3-markdown-it.d.ts",
+    "README.md"
+  ],
   "scripts": {
     "build": "vue-cli-service build --formats umd-min --target lib ./src/index.js",
     "lint": "vue-cli-service lint",

--- a/types/vue3-markdown-it.d.ts
+++ b/types/vue3-markdown-it.d.ts
@@ -1,0 +1,56 @@
+import type { App } from 'vue'
+import type { TocOptions } from 'markdown-it-toc-done-right';
+import type { AnchorOptions } from 'markdown-it-anchor';
+import type { Options as EmojiOptions } from 'markdown-it-emoji';
+
+interface TaskListOptions {
+  enabled?: boolean;
+  label?: boolean;
+  labelAfter?: boolean;
+}
+
+interface HighlightJsOptions {
+  /**
+    * Whether to automatically detect language if not specified.
+    */
+  auto?: boolean | undefined;
+
+  /**
+    * Whether to add the `hljs` class to raw code blocks (not fenced blocks).
+    */
+  code?: boolean | undefined;
+
+  /**
+    * Register other languages which are not included in the standard pack.
+    */
+  register?: {
+      [language: string]: (hljs?: HLJSApi) => Language;
+  } | undefined;
+
+  /**
+    * Whether to highlight inline code.
+    */
+  inline?: boolean | undefined;
+}
+
+interface VueMarkdownItProps {
+  anchor?: AnchorOptions
+  emoji?: EmojiOptions
+  highlight?: HighlightJsOptions
+  tasklists?: TaskListOptions
+  toc?: TocOptions
+  langPrefix?: string
+  quotes?: string
+  source?: string
+  html?: boolean
+  breaks?: boolean
+  linkify?: boolean
+  typographer?: boolean
+  xhtmlOut?: boolean
+}
+
+export declare const VueMarkdownIt: new () => {
+    $props: VueMarkdownItProps;
+};
+
+export function install(app: App)

--- a/types/vue3-markdown-it.d.ts
+++ b/types/vue3-markdown-it.d.ts
@@ -1,4 +1,4 @@
-import type { App } from 'vue'
+import type { VNodeProps, App } from 'vue'
 import type { TocOptions } from 'markdown-it-toc-done-right';
 import type { AnchorOptions } from 'markdown-it-anchor';
 import type { Options as EmojiOptions } from 'markdown-it-emoji';
@@ -50,7 +50,7 @@ interface VueMarkdownItProps {
 }
 
 export declare const VueMarkdownIt: new () => {
-    $props: VueMarkdownItProps;
+    $props: VNodeProps & VueMarkdownItProps;
 };
 
 export function install(app: App)


### PR DESCRIPTION
Using this allows us to register the `VueMarkdownIt` component in global scope using 

```ts
// components-global.d.ts
declare module 'vue' {
  export interface GlobalComponents {
    RouterLink: typeof import('vue-router')['RouterLink']
    RouterView: typeof import('vue-router')['RouterView']

    // this is now allowed
    VueMarkdownIt: typeof import('vue3-markdown-it')['VueMarkdownIt']
  }
}

export {}
```


Using volar in VSCode, this result with perfect integration !
![image](https://user-images.githubusercontent.com/3911343/136385636-0b30119b-37f5-4c6b-bfe2-c1a3a4b24b2f.png)

